### PR TITLE
ci: add condition to run publish job only when both main branch and version tag are pushed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,13 +2,14 @@ name: Publish to JSR
 
 on:
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
     branches:
       - "main"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:
+    if: github.ref == 'refs/heads/main' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Add condition to ensure publish job runs only when both main branch push and version tag push conditions are met