### PR TITLE
Release v1.2.6: Add .claude skills and update breakdownlogger

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,110 @@
+# BreakdownPrompt - Project Context
+
+## Overview
+Deno TypeScript library for managing and generating prompts from templates with variable replacement.
+Published as `@tettuan/breakdownprompt` on JSR.
+
+## Branch Rules (MUST FOLLOW)
+
+**NEVER commit directly to `main` or `develop`.** All changes go through this flow:
+
+```
+feature/*, fix/*, refactor/*, docs/*  (work branches)
+  ↓ PR (squash merge)
+release/vX.Y.Z
+  ↓ PR (merge commit)
+develop
+  ↓ PR (merge commit)
+main → vtag → JSR publish (automatic)
+```
+
+### When starting any work:
+
+1. Determine the current release branch: `git branch -a | grep release`
+2. If a release branch exists, branch from it: `git checkout -b feature/xxx release/vX.Y.Z`
+3. If no release branch exists, create one from develop first:
+   ```
+   git checkout develop && git pull origin develop
+   git checkout -b release/vX.Y.Z
+   ```
+   Then branch from it: `git checkout -b feature/xxx`
+
+### When committing:
+
+- Commit to your work branch (feature/*, fix/*, refactor/*, docs/*)
+- NEVER commit to main or develop directly
+- Push and create PR to the release branch
+
+### Branch naming:
+
+| Type | Prefix | Example |
+|------|--------|---------|
+| New feature | `feature/` | `feature/add-custom-variables` |
+| Bug fix | `fix/` | `fix/path-validation-error` |
+| Refactoring | `refactor/` | `refactor/replacer-module` |
+| Documentation | `docs/` | `docs/update-api-reference` |
+| Release prep | `release/` | `release/v1.2.6` |
+
+### Prohibited operations:
+
+- `git push origin main` — NEVER
+- `git push origin develop` — NEVER
+- `git commit` while on main or develop — NEVER
+- `git checkout -b feature/* main` — NEVER (branch from release/*)
+- `git checkout -b feature/* develop` — NEVER (branch from release/*)
+
+## Tech Stack
+- Runtime: Deno
+- Language: TypeScript (strict mode)
+- Testing: `deno test` with `@std/testing` and `@std/assert`
+- Logging: `@tettuan/breakdownlogger`
+- CI: `scripts/local_ci.sh` (local), GitHub Actions (remote)
+
+## Project Structure
+- `mod.ts` - Package entry point (public exports)
+- `src/` - Source code
+  - `core/` - Core logic (PromptManager, VariableReplacer, VariableMatcher, VariableProcessor)
+  - `validation/` - Validators (path, variable, markdown, reserved variable, parameter)
+  - `replacers/` - Variable replacer implementations (schema_file, input_text, input_text_file, destination_path)
+  - `types/` - Type definitions (PromptParams, PromptResult, Variables)
+  - `errors/` - Error classes (ValidationError, TemplateError, FileSystemError)
+  - `utils/` - Utilities (format, file, error handler)
+  - `version.ts` - VERSION constant and META
+- `tests/` - Test hierarchy
+  - `00_fixtures/` - Test fixtures and templates
+  - `01_unit/` - Unit tests
+  - `02_integration/` - Integration tests
+  - `03_system/` - System/E2E tests
+- `docs/` - Documentation (English *.md + Japanese *.ja.md)
+- `scripts/` - Shell scripts
+  - `local_ci.sh` - Local CI pipeline
+  - `bump_version.sh` - Version bump with PR workflow
+
+## Public API
+```typescript
+export { PromptManager } from "./src/core/prompt_manager.ts";
+export type { PromptResult } from "./src/types/prompt_result.ts";
+export type { PromptParams } from "./src/types/prompt_params.ts";
+export type { Variables } from "./src/types/variables.ts";
+export { FileSystemError, TemplateError, ValidationError } from "./src/errors.ts";
+export { META, VERSION } from "./src/version.ts";
+```
+
+## Conventions
+- Variable format in templates: `{variable_name}` (curly braces, snake_case, hyphens allowed)
+- Reserved variables: `schema_file`, `input_text`, `input_text_file`, `destination_path`
+- Formatting: 2-space indent, no tabs, 100 char line width, double quotes, semicolons
+- Test file naming: `*_test.ts`
+- Import policy: use `@std/` (JSR), not `https://deno.land/` URLs
+
+## Version Management
+- `deno.json` → `"version": "x.y.z"`
+- `src/version.ts` → `export const VERSION = "x.y.z"`
+- Both MUST match. Automated via `scripts/bump_version.sh`
+
+## Commands
+- `deno task test` - Run tests
+- `deno task fmt` - Format code
+- `deno task lint` - Lint code
+- `scripts/local_ci.sh` - Full local CI
+- `scripts/bump_version.sh` - Version bump with PR workflow

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(deno task test*)",
+      "Bash(deno task lint*)",
+      "Bash(deno task fmt*)",
+      "Bash(deno task ci*)",
+      "Bash(deno check *)",
+      "Bash(scripts/local_ci.sh*)",
+      "Bash(scripts/bump_version.sh*)",
+      "Bash(LOG_LEVEL=* deno test *)",
+      "Bash(DEBUG=* scripts/local_ci.sh*)"
+    ]
+  }
+}

--- a/.claude/skills/absolute-path-checker/SKILL.md
+++ b/.claude/skills/absolute-path-checker/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: absolute-path-checker
+description: Verify no absolute paths exist in implementation code when discussing tests, refactoring, portability, or directory hierarchy
+allowed-tools: [Grep, Read, Edit, Bash]
+---
+
+# Absolute Path Checker
+
+## Purpose
+
+Ensure no absolute paths (especially HOME directory paths) exist in implementation code, maintaining portability.
+
+## Trigger Conditions
+
+Auto-run when working on:
+- Test implementation/fixes
+- Refactoring
+- Portability improvements
+- Directory structure changes
+
+## Procedure
+
+### 1. Search for absolute paths
+
+Search implementation files (.ts, .js) for:
+
+```bash
+# HOME directory absolute paths
+grep -r "/Users/" --include="*.ts" --include="*.js" src/
+grep -r "/home/" --include="*.ts" --include="*.js" src/
+
+# Root-based absolute paths (excluding config files)
+grep -r '"/[a-z]' --include="*.ts" --include="*.js" src/
+```
+
+### 2. Classify results
+
+| Type | Action |
+|------|--------|
+| **Literals in implementation** | Must convert to relative path |
+| **Test output/logs** | Allowed (but not in test assertions) |
+| **Config defaults** | Replace with env vars or relative paths |
+| **Documentation/comments** | Allowed |
+
+### 3. Convert to relative paths
+
+Priority order:
+
+1. **Use existing variables**: `Deno.cwd()`, project-defined base paths
+2. **Use import.meta** (Deno/ESM):
+   ```typescript
+   const __dirname = new URL(".", import.meta.url).pathname;
+   const configPath = join(__dirname, "../config.json");
+   ```
+3. **Relative path literals**:
+   ```typescript
+   // Before
+   const path = "/Users/dev/project/data/file.txt";
+   // After
+   const path = "./data/file.txt";
+   ```
+
+### 4. Run tests after changes
+
+```bash
+deno task test
+```
+
+## Notes
+
+- `$HOME` and `~` paths are treated the same as absolute paths
+- Paths from `Deno.env.get("HOME")` are allowed
+- Use `join()` or `resolve()` for path construction, not string concatenation

--- a/.claude/skills/branch-management/SKILL.md
+++ b/.claude/skills/branch-management/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: branch-management
+description: Review and guide branch strategy when creating PRs, merging, or creating branches involving main, develop, and release branches
+allowed-tools: [Bash, Read, Grep, Glob]
+---
+
+# Branch Management Guide
+
+## Purpose
+
+Manage branch strategy, naming conventions, and PR rules for breakdownprompt.
+
+- Full release flow (version bump -> tag -> merge): see `/release-procedure` skill
+- CI execution and troubleshooting: see `/local-ci` skill
+
+## Branch Strategy
+
+### Flow
+
+```mermaid
+flowchart LR
+    subgraph Protected["Protected (no direct push)"]
+        main[main]
+        develop[develop]
+    end
+
+    subgraph Release["Release branches"]
+        release[release/vX.Y.Z]
+    end
+
+    subgraph Work["Work branches"]
+        feature[feature/*]
+        fix[fix/*]
+        refactor[refactor/*]
+        docs[docs/*]
+    end
+
+    develop -->|branch from| release
+    release -->|branch from| feature
+    release -->|branch from| fix
+    release -->|branch from| refactor
+    release -->|branch from| docs
+
+    feature -->|PR| release
+    fix -->|PR| release
+    refactor -->|PR| release
+    docs -->|PR| release
+
+    release -->|PR| develop
+    develop -->|PR| main
+```
+
+### Merge Direction
+
+```
+Work branch → release/vX.Y.Z → develop → main → vtag
+```
+
+## Rules
+
+| Operation | Allowed | Prohibited |
+|-----------|---------|------------|
+| Changes to main | PR merge from develop only | Direct push, merge from other branches |
+| Changes to develop | PR merge from release/* only | Direct push |
+| Create release/* | Branch from develop | Branch from main or work branches |
+| Create work branches | Branch from release/* | Branch from main or develop directly |
+
+## Procedures
+
+### Create a work branch
+
+```bash
+git checkout release/vX.Y.Z
+git checkout -b feature/my-feature
+```
+
+### Create a PR
+
+| Current branch | PR target | Command |
+|---------------|-----------|---------|
+| feature/*, fix/*, refactor/*, docs/* | release/vX.Y.Z | `gh pr create --base release/vX.Y.Z` |
+| release/* | develop | `gh pr create --base develop` |
+| develop | main | `gh pr create --base main` |
+
+### Merge a PR
+
+1. Verify CI passes: `gh pr checks <PR#>`
+2. Merge with appropriate strategy:
+
+| Merge method | Use case | Command |
+|-------------|----------|---------|
+| Squash | Work branch -> release (clean history) | `gh pr merge --squash` |
+| Merge | release -> develop (preserve history) | `gh pr merge --merge` |
+| Merge | develop -> main (preserve history) | `gh pr merge --merge` |
+
+3. Update local:
+
+```bash
+git checkout <target-branch>
+git pull origin <target-branch>
+```
+
+## Branch naming conventions
+
+```
+feature/*  - New features
+fix/*      - Bug fixes
+refactor/* - Refactoring
+docs/*     - Documentation changes
+release/vX.Y.Z - Release preparation
+```
+
+## Warning patterns
+
+| Operation | Warning |
+|-----------|---------|
+| `git push origin main` | Direct push to main is prohibited. Create a PR from develop. |
+| `git push origin develop` | Direct push to develop is prohibited. Create a PR from release/*. |
+| `git checkout -b feature/* develop` | Work branches must branch from release/*. |
+| `git merge main` | Merging from main is not expected. Check the branch origin. |

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: bump-version
+description: Bump the project version for release. Use when user says 'version', 'バージョン', or preparing a release.
+argument-hint: "[--major|--minor|--patch] [--status] [--step]"
+disable-model-invocation: true
+allowed-tools: [Bash, Read]
+---
+
+Run the version bump script with PR workflow.
+
+```bash
+scripts/bump_version.sh $ARGUMENTS
+```
+
+Default: `--patch`
+
+## Version files
+
+| File | Field |
+|------|-------|
+| `deno.json` | `"version": "x.y.z"` |
+| `src/version.ts` | `export const VERSION = "x.y.z"` |
+
+Both files MUST have matching versions.
+
+## Script workflow
+
+```
+A-1: Version update (deno.json, src/version.ts) with JSR latest check
+A-2: Local CI check → commit & push
+A-3: Create PR to develop
+B-1: Wait for PR merge (remote CI must pass)
+B-2: Create PR to main
+C-1: Wait for PR merge (remote CI must pass)
+C-2: Create vtag on main merge commit
+```
+
+Use `--status` to check progress. Use `--step` for single-step execution.
+
+Only run when explicitly ordered. Do not speculate about releases.

--- a/.claude/skills/ci-troubleshooting/SKILL.md
+++ b/.claude/skills/ci-troubleshooting/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: ci-troubleshooting
+description: Use when encountering CI errors, JSR connection issues, 'deno task ci' failures, or sandbox-related build problems. Provides solutions for common CI issues.
+allowed-tools: [Bash, Read, Edit, Grep, Glob]
+---
+
+# CI Troubleshooting
+
+## CI Pipeline (local_ci.sh)
+
+`scripts/local_ci.sh` runs these stages in order:
+
+1. **lock** - Remove and regenerate deno.lock
+2. **check** - Type checking (batch, then individual on failure)
+3. **jsr-check** - JSR publish dry-run
+4. **test** - Run all tests hierarchically
+5. **fmt** - Format check
+6. **lint** - Deno lint
+
+## Network / Sandbox Issues
+
+### JSR Connection Failed
+
+```
+error: JSR package manifest for '@std/path' failed to load.
+Import 'https://jsr.io/@std/path/meta.json' failed.
+```
+
+**Solution**: Run with sandbox disabled if needed:
+
+```typescript
+Bash({
+  command: "scripts/local_ci.sh",
+  dangerouslyDisableSandbox: true,
+})
+```
+
+## Lint Errors
+
+### Common Rules and Fixes
+
+| Rule | Error | Fix |
+|------|-------|-----|
+| `no-console` | console.log in library code | Add `// deno-lint-ignore no-console` |
+| `prefer-ascii` | Japanese in comments | Change to English |
+| `no-await-in-loop` | await in for loop | Add ignore or refactor to Promise.all |
+| `eqeqeq` | `!=` instead of `!==` | Use strict equality |
+| `explicit-function-return-type` | Missing return type | Add `: ReturnType` |
+| `ban-unused-ignore` | Unused lint ignore | Remove or adjust ignore list |
+
+### File-Level Lint Ignore
+
+Add at top of file:
+
+```typescript
+// deno-lint-ignore-file no-console prefer-ascii
+```
+
+### Line-Level Lint Ignore
+
+```typescript
+// deno-lint-ignore no-console
+console.log("Debug output");
+```
+
+## Test Failures
+
+### Flaky Tests (Timing Issues)
+
+**Problem**: Parallel execution with small delays
+
+**Solution**: Sequential execution with adequate delay
+
+```typescript
+for (let i = 0; i < 10; i++) {
+  ids.push(generateId());
+  await new Promise((r) => setTimeout(r, 5));
+}
+```
+
+### Type Errors in Tests
+
+Check for:
+- Missing type assertions (`as Type`)
+- Incorrect mock implementations
+- Outdated test fixtures after interface changes
+
+## Format Errors
+
+```bash
+# Check without fixing
+deno fmt --check
+
+# Fix all
+deno fmt
+```
+
+## Quick Debugging
+
+```bash
+# Type check only
+deno check mod.ts
+
+# Lint only
+deno lint
+
+# Single test file
+deno test --allow-env --allow-write --allow-read tests/01_unit/01_core/01_prompt_manager_test.ts
+
+# Verbose test output
+LOG_LEVEL=debug deno test --allow-env --allow-write --allow-read 2>&1 | head -100
+```
+
+## Related Skills
+
+- CI execution: `/local-ci`
+- Release flow: `/release-procedure`

--- a/.claude/skills/docs-consistency/SKILL.md
+++ b/.claude/skills/docs-consistency/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: docs-consistency
+description: Verify and fix documentation to match implementation. Use when updating docs, releasing versions, or when user mentions 'docs consistency', 'docs verify', 'ドキュメント更新', 'docsを直して'.
+allowed-tools: [Read, Edit, Grep, Glob, Bash]
+---
+
+# Docs Consistency
+
+Docs explain implementation; they do not rewrite design.
+Flow: design intent (What/Why) -> implementation survey (How) -> docs update (explanation).
+
+## Phase 1: Extract Design Intent
+
+Read design docs (`docs/`) and identify What, Why, constraints, and what users need to know.
+
+Key design docs for breakdownprompt:
+- `docs/design_pattern.md` / `docs/design_pattern.ja.md`
+- `docs/type_of_variables.ja.md` / `docs/variables.ja.md`
+- `docs/path_validation.md`
+- `docs/return_specification.ja.md`
+
+## Phase 2: Survey Implementation
+
+Identify implementation files, public API, defaults, and edge cases.
+
+Key implementation files:
+- `mod.ts` - Public exports
+- `src/core/prompt_manager.ts` - Main API
+- `src/types/` - Type definitions
+- `src/validation/` - Validators
+- `src/replacers/` - Variable replacers
+
+## Phase 3: Diff Against Current Docs
+
+Compare design + implementation against current docs. Build a diff table:
+
+| Item | Design/Implementation | Current docs | Gap |
+|------|----------------------|-------------|-----|
+| Reserved variables | 4 types | Documented | None |
+| Custom variables | Hyphen support | Missing | Add |
+
+## Phase 4: Fix Docs
+
+Do not change design docs — only update implementation-facing docs.
+
+| Priority | Target |
+|----------|--------|
+| 1 | README.md |
+| 2 | docs/user_guide.md |
+| 3 | docs/api_reference.md |
+
+## Phase 5: Verify
+
+```bash
+# Check public exports match docs
+grep "^export" mod.ts
+
+# Check documented types exist
+grep -r "PromptManager\|PromptResult\|PromptParams\|Variables" docs/ README.md
+
+# Check code examples in docs
+grep -A 5 "```typescript" README.md docs/user_guide.md
+```
+
+## Phase 6: Language
+
+| Pattern | Language |
+|---------|---------|
+| `*.md` | English (primary) |
+| `*.ja.md` | Japanese (supplementary) |
+
+## Checklist
+
+```
+Phase 1: - [ ] Read docs/, identified design intent
+Phase 2: - [ ] Identified implementation files, surveyed public API
+Phase 3: - [ ] Built diff table against current docs
+Phase 4: - [ ] Updated README.md and relevant docs
+Phase 5: - [ ] Verified consistency (exports, types, examples)
+```
+
+## Related Skills
+
+| Skill | Purpose | When |
+|-------|---------|------|
+| `docs-consistency` | Verify & fix | Release prep, periodic review |
+| `update-docs` | Create & update | Feature additions, changes |
+| `update-changelog` | CHANGELOG update | Feature completion |

--- a/.claude/skills/fix-checklist/SKILL.md
+++ b/.claude/skills/fix-checklist/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: fix-checklist
+description: Use when about to fix code, modify implementation, or address errors. MUST read before saying "fix", "修正します", "直す", "対処する". Prevents symptom-driven fixes.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Before You Fix: Stop and Think
+
+**Read this BEFORE making any code changes.**
+
+## The Rule
+
+```
+Stop. Think carefully. Verify one by one. Dig deeper.
+```
+
+## Why This Exists
+
+Symptom-driven fixes are wrong fixes. Seeing an error and immediately "fixing" it without understanding WHY leads to:
+
+- Breaking the design
+- Introducing new bugs
+- Wasting time on wrong solutions
+
+## Checklist (Do Not Skip)
+
+### 1. Stop
+
+Do NOT write code yet. Do NOT edit files yet.
+
+### 2. Ask "Why?"
+
+The error is a symptom. Ask:
+- Why is this error occurring?
+- What is the system trying to do?
+- What did the system expect vs what happened?
+
+### 3. Read the Design
+
+Before changing ANY code:
+- Find the relevant design document in `docs/`
+- Read it completely
+- Understand the intended behavior
+
+Key locations for breakdownprompt:
+- `docs/design_pattern.md` - Architecture and design patterns
+- `docs/type_of_variables.ja.md` / `docs/variables.ja.md` - Variable system design
+- `docs/path_validation.md` - Path validation rules
+- `docs/return_specification.ja.md` - Return value contracts
+- `src/types/` - Type definitions (interface contracts)
+
+### 4. Trace the Flow
+
+Follow the execution path:
+1. What triggered this code?
+2. What state was expected?
+3. Where did it diverge?
+
+For breakdownprompt, typical flow:
+```
+PromptManager.generatePrompt()
+  → TemplateFile (load template)
+  → ParameterManager (validate params)
+  → VariableProcessor (replace variables)
+    → VariableMatcher (find variables in template)
+    → Replacers (substitute values)
+  → PromptResult (return result)
+```
+
+### 5. Identify Root Cause
+
+The fix location is often NOT where the error appears.
+
+| Error Location | Root Cause Location |
+|----------------|---------------------|
+| Runtime validation | Type definitions in `src/types/` |
+| Variable not replaced | Replacer in `src/replacers/` |
+| Path validation error | Validator in `src/validation/` |
+| Test failure | Implementation logic in `src/core/` |
+
+### 6. Verify Your Understanding
+
+Before fixing, state:
+- What is the root cause?
+- Why does the design work this way?
+- What is the minimal correct fix?
+
+### 7. Then Fix
+
+Only now: make the smallest change that addresses the root cause.
+
+## Anti-Patterns
+
+**Bad**: "Error says X not found, so add X"
+
+**Good**: "Error says X not found. Why is X expected? What does the design say about X?"
+
+## Investigation Output
+
+For complex problems, write investigation results to `tmp/`:
+
+```
+tmp/investigation/<issue-name>/
+├── overview.md      # Problem overview (mermaid diagram required)
+├── trace.md         # Execution flow trace
+└── root-cause.md    # Root cause and fix plan
+```
+
+Rules:
+1. Use mermaid diagrams to visualize structure
+2. Keep each file under 500 lines
+3. Focus on identifying the essential structure of the problem

--- a/.claude/skills/local-ci/SKILL.md
+++ b/.claude/skills/local-ci/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: local-ci
+description: Run local CI checks before merge or push. Use when user says 'CI', 'ローカルCI', or before creating PRs.
+allowed-tools: [Bash, Read]
+---
+
+Run the local CI script to validate the project.
+
+## Steps
+
+1. Run `scripts/local_ci.sh`
+2. If errors occur, re-run with debug logging: `DEBUG=true scripts/local_ci.sh`
+3. Report results
+
+## CI pipeline stages (local_ci.sh)
+
+1. **Lock regeneration** - Remove and regenerate deno.lock
+2. **Type check** - `deno check` on entry points and all src/*.ts
+3. **JSR check** - `npx jsr publish --dry-run --allow-dirty`
+4. **Tests** - All test files in `tests/` hierarchically, then full suite with `-A`
+5. **Type check** - `deno check mod.ts`
+6. **Format** - `deno fmt --check`
+7. **Lint** - `deno lint`
+
+DO NOT push until all checks pass.

--- a/.claude/skills/refactoring/SKILL.md
+++ b/.claude/skills/refactoring/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: refactoring
+description: Use when refactoring code, reorganizing modules, renaming types, deleting old paths, or migrating architecture. MUST read before any structural code change. Prevents incomplete refactoring.
+allowed-tools: [Read, Glob, Grep, Edit, Write, Bash, Task]
+---
+
+# Refactoring
+
+Prove the new path inherits every contract from the old path before deleting it. If you cannot prove it, do not delete.
+
+## Failure Patterns
+
+| Pattern | Why it breaks | Prevention |
+|---------|--------------|------------|
+| Old path deleted + new path incomplete | Contract breaks in intermediate state | List all contracts in Before/After table before deleting |
+| Build cache inconsistency | Cache serves old module instead of updated one | Run --reload or clear cache after every change |
+| Dead code left behind | Produces false positives in grep/search | Delete superseded code in the same PR |
+| Documentation not updated | Users cannot discover changes | Grep docs for changed names and update all references |
+
+## Phase 1: Inventory
+
+Map everything being removed or changed before writing any code.
+
+**1. Removal Inventory** — List what is being removed, who consumes it.
+
+```markdown
+| Item | File | Consumers |
+|------|------|-----------|
+| PromptManager.oldMethod | src/core/prompt_manager.ts:42 | tests, mod.ts |
+```
+
+**2. Consumer Audit** — Grep imports and call sites. If any consumer has no migration target, deletion is not allowed.
+
+```bash
+grep -r "OldName" --include="*.ts" src/ tests/ mod.ts
+```
+
+## Phase 2: Contract & Verification
+
+**3. Before/After Table** — Any row with empty "After" = not ready.
+
+```markdown
+| Behavior | Before | After | Verified |
+|----------|--------|-------|----------|
+| schema_file replacement | SchemaFileReplacer.replace() | New implementation | [ ] |
+```
+
+**4. Verification Design** — Match proof method to complexity:
+
+| Path characteristic | Proof method |
+|--------------------|-------------|
+| Straight line, 1-2 hops | Code review sufficient |
+| Contains branches, filters | Automated test on boundary |
+| Depends on external state | E2E execution |
+
+## Phase 3: Execute
+
+**5.** 1 commit = 1 concern. Separate: add new path -> migrate consumers -> delete old path -> update docs.
+
+**6.** Every commit must pass `scripts/local_ci.sh`. If intermediate state breaks, commit granularity is too coarse.
+
+**7.** Delete dead code in the same PR. "Cleanup later" never comes.
+
+## Phase 4: Verify
+
+**8. Cache clear**
+
+```bash
+deno cache --reload mod.ts
+```
+
+**9. Consumer grep** — Ensure zero remaining references:
+
+```bash
+grep -r "OldName" --include="*.ts" src/ tests/ mod.ts | grep -v test
+```
+
+**10. Docs grep** — Ensure zero stale references:
+
+```bash
+grep -r "OldName" --include="*.md" docs/ README.md
+```
+
+## Anti-Patterns
+
+| Bad | Good |
+|-----|------|
+| Delete old path, implement new path later | Make new path work first, then delete old |
+| Assume "nobody uses this" without grep | Show evidence via consumer audit |
+| Combine refactor and feature in one PR | Separate for bisectability |
+| Skip cache clear after refactor | Always --reload after changes |
+
+## Related Skills
+
+| Skill | When to use together |
+|-------|---------------------|
+| `fix-checklist` | Root cause analysis before deciding what to refactor |
+| `docs-consistency` | Documentation updates after refactoring |

--- a/.claude/skills/release-procedure/SKILL.md
+++ b/.claude/skills/release-procedure/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: release-procedure
+description: Use when user says 'release', 'リリース', 'publish', 'vtag', 'version up', 'バージョンアップ', or discusses merging to main/develop. Guides through version bump and release flow.
+disable-model-invocation: true
+allowed-tools: [Bash, Read, Edit, Grep, Glob]
+---
+
+# Release Procedure
+
+## Responsibilities
+
+Manage the full release flow (version bump -> tag -> PR -> merge).
+
+- Branch strategy details: see `/branch-management` skill
+- CI execution and troubleshooting: see `/local-ci`, `/ci-troubleshooting` skills
+
+## Version Files
+
+| File | Field | Example |
+|------|-------|---------|
+| `deno.json` | `"version": "x.y.z"` | `"version": "1.2.5"` |
+| `src/version.ts` | `export const VERSION = "x.y.z"` | `export const VERSION = "1.2.5"` |
+
+Both files MUST have matching versions.
+
+## Version Bump Type
+
+```
+Patch (x.y.Z): Bug fixes, documentation improvements
+Minor (x.Y.0): New features (backwards compatible)
+Major (X.0.0): Breaking changes
+```
+
+## Release Flow
+
+```mermaid
+sequenceDiagram
+    participant R as release/vX.Y.Z
+    participant D as develop
+    participant M as main
+    participant T as vtag
+
+    Note over R: 1. Version bump
+    R->>R: deno.json, version.ts update
+    Note over R: 2. Local CI
+    R->>R: scripts/local_ci.sh
+    R->>R: 3. git commit & push
+
+    R->>D: 4. PR (release -> develop)
+    Note over D: 5. CI check (all pass)
+    D->>D: PR merge
+
+    D->>M: 6. PR (develop -> main)
+    Note over M: 7. CI check (all pass)
+    M->>M: PR merge
+    Note over M: JSR publish (automatic)
+
+    M->>T: 8. vtag
+    Note over T: git tag vX.Y.Z
+```
+
+## Detailed Steps
+
+### Step 0: Preparation
+
+```bash
+# Verify work branches are merged into release/*
+git checkout release/vX.Y.Z
+git log --oneline -10
+```
+
+### Step 1: Version bump on release/*
+
+```bash
+# Create release branch from develop
+git checkout develop
+git checkout -b release/vX.Y.Z
+
+# Run automated version bump
+scripts/bump_version.sh --patch  # or --minor, --major
+
+# Verify
+grep '"version"' deno.json
+grep 'export const VERSION' src/version.ts
+```
+
+### Step 2: Local CI
+
+```bash
+scripts/local_ci.sh
+```
+
+### Step 3: Commit & push
+
+```bash
+git add deno.json src/version.ts
+git commit -m "chore: bump version to X.Y.Z"
+git push -u origin release/vX.Y.Z
+```
+
+### Step 4: release/* -> develop PR
+
+```bash
+gh pr create --base develop --head release/vX.Y.Z \
+  --title "Release vX.Y.Z: <summary>" \
+  --body "## Summary
+- <changes>
+
+## Version
+- X.Y.Z"
+```
+
+### Step 5: CI check & merge to develop
+
+```bash
+gh pr checks <PR#> --watch
+gh pr merge <PR#> --merge
+```
+
+### Step 6: develop -> main PR
+
+```bash
+gh pr create --base main --head develop \
+  --title "Release vX.Y.Z" \
+  --body "Release version X.Y.Z to production"
+```
+
+### Step 7: CI check & merge to main
+
+```bash
+gh pr checks <PR#> --watch
+gh pr merge <PR#> --merge
+```
+
+**Automatic**: JSR publish runs on main merge.
+
+### Step 8: vtag
+
+```bash
+git fetch origin main
+git tag vX.Y.Z origin/main
+git push origin vX.Y.Z
+```
+
+### Step 9: Cleanup
+
+```bash
+git branch -D release/vX.Y.Z
+git push origin --delete release/vX.Y.Z
+```
+
+## Important: No Consecutive Merges Without User Approval
+
+**Each merge step (release -> develop, develop -> main) requires explicit user instruction.**
+
+Prohibited:
+- Consecutive merges without user confirmation
+- Merging to main from vague instructions like "release it"
+- Self-initiated develop -> main merge
+
+Correct:
+1. Report PR creation, wait for user instruction
+2. Confirm explicit scope ("merge to develop" or "merge to main")
+3. Wait for user instruction before vtag creation
+
+## Quick Reference
+
+```
+Version bump:
+  scripts/bump_version.sh [--major|--minor|--patch]
+  scripts/bump_version.sh --status  # Check progress
+
+Release flow:
+  1. release/* -> develop PR
+  2. gh pr checks <PR#> --watch
+  3. gh pr merge <PR#> --merge
+  4. develop -> main PR
+  5. gh pr checks <PR#> --watch
+  6. gh pr merge <PR#> --merge (JSR publish automatic)
+  7. vtag: git tag vX.Y.Z origin/main && git push origin vX.Y.Z
+  8. Cleanup: branch deletion (/branch-management)
+
+Related skills:
+  - CI execution/troubleshooting: /local-ci, /ci-troubleshooting
+  - Branch strategy/deletion: /branch-management
+```

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: review
+description: Review code changes for quality, correctness, and adherence to project conventions. Use when user says 'review', 'レビュー', or asks to check code quality.
+argument-hint: "[file-or-path]"
+allowed-tools: [Read, Grep, Glob, Bash]
+---
+
+# Code Review
+
+Review code changes for quality and correctness.
+
+## Steps
+
+1. If `$ARGUMENTS` is provided, review the specified file or path.
+   Otherwise, review staged or unstaged git changes via `git diff`.
+
+2. Check for:
+
+### Type Safety
+- Strict mode compliance
+- Proper use of `PromptResult`, `PromptParams`, `Variables` types
+- No `any` types without justification
+
+### Naming Conventions
+- Template variables: `{snake_case}` with curly braces (hyphens allowed)
+- TypeScript code: camelCase for variables/functions, PascalCase for types/classes
+- Test files: `*_test.ts`
+
+### Error Handling
+- Use project error classes: `ValidationError`, `TemplateError`, `FileSystemError`
+- Proper error propagation via `PromptResult.success`
+
+### Path Validation
+- File-related parameters validated through `src/validation/path_validator.ts`
+- No absolute paths in implementation code (see `/absolute-path-checker`)
+
+### Test Coverage
+- Corresponding tests exist in `tests/` for new/changed functionality
+- Tests follow the hierarchy: `01_unit/` -> `02_integration/` -> `03_system/`
+
+### Import Policy
+- Use `@std/` imports (JSR), not `https://deno.land/` URLs
+- Use import map entries from `deno.json`
+
+### Formatting
+- 2-space indent, no tabs, 100 char line width
+- Double quotes, semicolons
+
+3. Report findings with file paths and line numbers.

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: run-tests
+description: Run tests with debug logging. Use when user says 'test', 'テスト', or asks to verify changes.
+argument-hint: "[test-file-path]"
+allowed-tools: [Bash, Read, Grep, Glob]
+---
+
+Run the specified test file with debug output.
+
+```bash
+LOG_LEVEL=debug deno test $ARGUMENTS --allow-env --allow-write --allow-read
+```
+
+If no argument is provided, run all tests:
+
+```bash
+LOG_LEVEL=debug deno test --allow-env --allow-write --allow-read
+```
+
+## Test hierarchy
+
+Tests are in `tests/` with the following structure:
+
+```
+tests/
+├── 00_fixtures/   # Test fixtures and templates
+├── 01_unit/       # Unit tests
+├── 02_integration/ # Integration tests
+└── 03_system/     # System/E2E tests
+```
+
+Test file naming: `*_test.ts`

--- a/.claude/skills/update-changelog/SKILL.md
+++ b/.claude/skills/update-changelog/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: update-changelog
+description: Use when completing features, fixes, or changes that should be recorded. Updates CHANGELOG.md with concise, searchable entries following Keep a Changelog format.
+allowed-tools: [Read, Edit, Grep, Glob]
+---
+
+# CHANGELOG Update
+
+## Purpose
+
+Maintain a clear, searchable record of changes in CHANGELOG.md.
+
+## Trigger Conditions
+
+- Completing a new feature
+- Fixing a bug
+- Making breaking changes
+- Changing existing behavior
+- Removing functionality
+
+## Format
+
+This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+### Section Types
+
+| Section | Use When |
+|---------|----------|
+| `Added` | New feature or capability |
+| `Changed` | Existing behavior modified |
+| `Deprecated` | Feature will be removed |
+| `Removed` | Feature was removed |
+| `Fixed` | Bug fix |
+| `Security` | Security vulnerability fix |
+
+## Writing Good Entries
+
+### Principles
+
+1. **Searchable**: Include keywords users would search for
+2. **Concise**: One line per change
+3. **User-focused**: Describe the impact, not the implementation
+4. **Specific**: Include variable names, type names, or config names
+
+### Good Examples
+
+```markdown
+### Added
+- Custom variable support with `{variable-name}` syntax (hyphens allowed)
+- `Variables` type for typed variable definitions
+
+### Changed
+- `PromptManager.generatePrompt()` now validates all reserved variables before replacement
+
+### Fixed
+- Fixed `{destination_path}` replacement failing when path contains spaces
+```
+
+### Bad Examples
+
+```markdown
+# Too vague
+### Added
+- New feature for templates
+
+# Too implementation-focused
+### Changed
+- Refactored VariableReplacer to use async/await
+
+# Missing context
+### Fixed
+- Fixed the bug
+```
+
+## Process
+
+1. Read current CHANGELOG.md (create if it doesn't exist)
+2. Identify change category (Added/Changed/Fixed/etc.)
+3. Write one-line entry: `<What>: <Impact> (\`identifier\`)`
+4. Place under `[Unreleased]` section
+5. During release, move entries to `[x.y.z] - YYYY-MM-DD`

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: update-docs
+description: Use when implementing new features, changing behavior, or modifying the public API. Documents changes in README and relevant docs.
+allowed-tools: [Read, Edit, Grep, Glob, Bash]
+---
+
+# Documentation Update
+
+## Purpose
+
+Ensure user-facing changes are properly documented across all relevant locations.
+
+## Trigger Conditions
+
+- Adding new public API methods or types
+- Changing existing behavior
+- Adding new features or capabilities
+- Modifying variable replacement rules
+- Making breaking changes
+
+## Documentation Locations
+
+| Location | Purpose | Update Criteria |
+|----------|---------|-----------------|
+| `README.md` | Quick reference, installation, usage | Major features, API changes |
+| `docs/user_guide.md` | Detailed usage guide | Complex features, tutorials |
+| `docs/api_reference.md` | API documentation | All public API changes |
+| `docs/design_pattern.md` | Architecture docs | Structural changes |
+| `docs/path_validation.md` | Path validation rules | Validation behavior changes |
+| `.claude/CLAUDE.md` | Development guidelines | Internal workflow changes |
+
+## Decision Matrix
+
+```
+Change Type → Documentation Scope
+├── New public API (type, function, class)
+│   ├── README.md: Brief mention with example
+│   ├── docs/api_reference.md: Full signature and usage
+│   └── mod.ts: Export and JSDoc comment
+├── New feature
+│   ├── README.md: Brief description
+│   └── docs/user_guide.md: Detailed usage (if complex)
+├── Behavior change
+│   ├── README.md: Update existing description
+│   └── CHANGELOG.md: Note the change
+├── Variable system change
+│   ├── README.md: Update template format section
+│   └── docs/variables.ja.md / docs/type_of_variables.ja.md: Update design docs
+└── Internal change
+    └── .claude/CLAUDE.md: If affects development workflow
+```
+
+## Process
+
+1. Identify what changed: `git diff --name-only`
+2. Categorize: API change? Feature? Behavior change?
+3. Update appropriate documentation locations
+4. Verify code examples in docs still work
+
+## Guidelines
+
+- **Concise**: One sentence per feature in README
+- **Example-first**: Show usage before explaining
+- **Searchable**: Include keywords users would search for
+
+## What NOT to Document
+
+- Internal implementation details (unless in design docs)
+- Temporary workarounds
+- Debug-only options

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: workflow
+description: How to approach work. Applies to all tasks including implementation, planning, investigation, design, review, and auditing.
+---
+
+# Workflow
+
+Main Agent acts as conductor: plan, delegate, judge, integrate. Never do hands-on work yourself.
+
+```mermaid
+flowchart LR
+    A[Plan] --> B[Done Criteria] --> C[Team] --> D[ToDo]
+    D --> E[Delegate] --> F[Record] --> G{Next?}
+    G -->|Y| E
+    G -->|N| H[Done]
+```
+
+## Conductor Pattern
+
+Delegate all investigation and implementation to Sub Agents to preserve context for decision-making.
+
+| Do | Do NOT |
+|----|--------|
+| Plan, delegate, judge, integrate | Explore files, write code, run tests |
+| Record progress after each ToDo | Work on multiple ToDos simultaneously |
+| Launch parallel Sub Agents for independent tasks | Hold context that Sub Agents should hold |
+
+### Delegation criteria
+
+| Condition | Action |
+|-----------|--------|
+| Trivial fix (typo, 3 lines) or single known-location edit | Self |
+| Investigation, multi-file change, or insufficient info | Delegate |
+
+When in doubt, delegate.
+
+### Sub Agent types
+
+| Purpose | Agent Type |
+|---------|-----------|
+| Search, explore | Explore |
+| Design comparison | Plan |
+| Implement, test, verify | general-purpose |
+
+## Rules
+
+| # | Rule |
+|---|------|
+| 1 | Conductor delegates all hands-on work to Sub Agents |
+| 2 | Externalize thinking to `tmp/<task>/` (plan.md, progress.md, analysis.md) |
+| 3 | Complete one -> record -> next. No self-parallelism (Sub Agent parallelism is fine) |
+| 4 | Decompose Plan into ToDos via TaskCreate |
+| 5 | Team table in plan.md. First row is always Conductor. 1 role = 1 purpose |
+| 6 | Delegate by type: explore=Explore / design=Plan / implement+verify=general-purpose |
+| 7 | Define Done Criteria first. Incomplete until all items pass |
+| 8 | Record to progress.md immediately on completion |
+| 9 | Technical decisions: decide without asking. Policy decisions: present options with recommendation |
+| 10 | Visualize dependencies and ToDo map in analysis.md with Mermaid |
+| 11 | Structural code changes require `refactoring` skill first |
+
+## tmp/ structure
+
+```
+tmp/<task>/
+├── plan.md        # Goal, Done Criteria, Team, Approach, Scope
+├── progress.md    # Incremental records
+├── analysis.md    # Mermaid diagrams
+└── investigation/ # Sub Agent results
+```
+
+## Plan template
+
+```markdown
+# Plan: <task name>
+## Goal
+## Done Criteria
+- [ ] <checkable condition>
+## Team
+| Role | Purpose | Agent Type | ToDo |
+|------|---------|-----------|------|
+| Conductor | Plan, delegate, judge, integrate | Main Agent | Overall |
+## Approach
+## Scope
+Do: / Do not:
+```

--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,10 @@ tmp/*
 .agent/
 .agent/*
 
+# Claude Code local files
+.claude/settings.local.json
+.claude/CLAUDE.local.md
+
 # Test output directories
 test_output/
 test_fixtures/
@@ -151,9 +155,36 @@ test_fixtures/
 .vscode/
 .idea/
 
-# OS
+# macOS
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+.LSOverride
+Icon?
+.fseventsd
+.TemporaryItems
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows
 Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Linux
+*~
+.directory
 
 # Coverage directory
 coverage/

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tettuan/breakdownprompt",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "exports": "./mod.ts",
   "tasks": {
     "test": "LOG_LEVEL=debug deno test --allow-read --allow-write --allow-env",

--- a/deno.json
+++ b/deno.json
@@ -19,7 +19,7 @@
     "@std/testing": "jsr:@std/testing@^1.0.11",
     "std/": "jsr:@std/",
     "testing/": "jsr:@std/testing/",
-    "@tettuan/breakdownlogger": "jsr:@tettuan/breakdownlogger@^0.1.10",
+    "@tettuan/breakdownlogger": "jsr:@tettuan/breakdownlogger@^1.1.1",
     "$std/": "https://deno.land/std@0.208.0/",
     "vitest": "npm:vitest@^3.1.2"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -9,7 +9,7 @@
     "jsr:@std/path@1": "1.0.9",
     "jsr:@std/path@~0.220.1": "0.220.1",
     "jsr:@std/testing@~0.220.1": "0.220.1",
-    "jsr:@tettuan/breakdownlogger@~0.1.10": "0.1.10",
+    "jsr:@tettuan/breakdownlogger@^1.1.1": "1.1.1",
     "npm:vitest@^3.1.2": "3.2.4_vite@7.0.5__picomatch@4.0.3"
   },
   "jsr": {
@@ -53,8 +53,8 @@
         "jsr:@std/assert@~0.220.1"
       ]
     },
-    "@tettuan/breakdownlogger@0.1.10": {
-      "integrity": "3094af14f9271234b01280c4cf379d36f7b429531a434f169d3dce569d60e146"
+    "@tettuan/breakdownlogger@1.1.1": {
+      "integrity": "21fc81012649b01cd3adc71c7f432454508d565e3030439d511389a844d371cf"
     }
   },
   "npm": {
@@ -750,7 +750,7 @@
       "jsr:@std/path@~0.220.1",
       "jsr:@std/testing@*",
       "jsr:@std/testing@^1.0.11",
-      "jsr:@tettuan/breakdownlogger@~0.1.10",
+      "jsr:@tettuan/breakdownlogger@^1.1.1",
       "npm:vitest@^3.1.2"
     ]
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -10,7 +10,7 @@
  * across different execution contexts, including tests and subprocesses.
  * @constant
  */
-export const VERSION = "1.2.5";
+export const VERSION = "1.2.6";
 
 /**
  * Metadata about the package.

--- a/tests/01_unit/03_utils/01_logger_test.ts
+++ b/tests/01_unit/03_utils/01_logger_test.ts
@@ -65,11 +65,13 @@ export const TEST_PARAMS = {
   },
 };
 
-// Setup: Mock console.log to capture output
+// Setup: Mock console methods to capture output
 let capturedOutput: string[] = [];
 const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+const originalConsoleError = console.error;
 
-function mockConsoleLog(...args: unknown[]): void {
+function formatArgs(...args: unknown[]): string {
   const formattedArgs = args.map((arg) => {
     if (typeof arg === "object" && arg !== null) {
       if (arg instanceof Error) {
@@ -83,19 +85,35 @@ function mockConsoleLog(...args: unknown[]): void {
     }
     return String(arg);
   });
-  capturedOutput.push(formattedArgs.join(" "));
+  return formattedArgs.join(" ");
+}
+
+function mockConsoleLog(...args: unknown[]): void {
+  capturedOutput.push(formatArgs(...args));
+}
+
+function mockConsoleWarn(...args: unknown[]): void {
+  capturedOutput.push(formatArgs(...args));
+}
+
+function mockConsoleError(...args: unknown[]): void {
+  capturedOutput.push(formatArgs(...args));
 }
 
 // Setup: Logger test environment
 function setupLoggerTest(): void {
   capturedOutput = [];
   console.log = mockConsoleLog;
+  console.warn = mockConsoleWarn;
+  console.error = mockConsoleError;
   // Set environment variable for log level
   Deno.env.set("LOG_LEVEL", "debug");
 }
 
 function teardownLoggerTest(): void {
   console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+  console.error = originalConsoleError;
   // Clean up environment variable
   Deno.env.delete("LOG_LEVEL");
 }


### PR DESCRIPTION
## Summary
- Add .claude skill hierarchy (14 skills) adapted for breakdownprompt
- Add CLAUDE.md project context with branch strategy rules
- Add settings.json with auto-allowed Bash commands
- Update @tettuan/breakdownlogger from ^0.1.10 to ^1.1.1
- Fix logger test for v1.x console method routing
- Expand .gitignore with macOS/Windows/Linux OS entries
- Bump version to 1.2.6

## Version
- 1.2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)